### PR TITLE
Updated model.cosine_similarities to model.wv.cosine_similarities for compatibility

### DIFF
--- a/responsibly/we/utils.py
+++ b/responsibly/we/utils.py
@@ -81,7 +81,10 @@ def cosine_similarities_by_words(model, word, words):
 
     vec = model[word]
     vecs = [model[w] for w in words]
-    return model.cosine_similarities(vec, vecs)
+#     This line was changed by Leonardo Alchieri
+#     It is done in order to function with later
+#     versions of gensim.
+    return model.wv.cosine_similarities(vec, vecs)
 
 
 def update_word_vector(model, word, new_vector):


### PR DESCRIPTION
The latest versions of gensim (it should be from version 3.30) need `model.wv.cosine_similarities` instead of `model.cosine_similarities`. For compatibility reasons, I think the code can be updated with this small change, as least in a new release. 